### PR TITLE
Filter datamesh source

### DIFF
--- a/src/rompy/core/source.py
+++ b/src/rompy/core/source.py
@@ -262,6 +262,8 @@ class SourceDatamesh(SourceBase):
             geofilter=self._geofilter(filters, coords),
             timefilter=self._timefilter(filters, coords),
         )
+        if filters:
+            ds = filters(ds)
         return ds
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -23,7 +23,7 @@ from rompy.utils import load_entry_points
 
 load_entry_points("rompy.source")
 from rompy.core.filters import Filter
-from rompy.core.types import DatasetCoords
+from rompy.core.types import DatasetCoords, Slice
 
 HERE = Path(__file__).parent
 DATAMESH_TOKEN = os.environ.get("DATAMESH_TOKEN")
@@ -191,9 +191,9 @@ def test_source_datamesh():
         datasource="era5_wind10m", token=DATAMESH_TOKEN
     )
     filters = Filter()
-    filters.crop.update(dict(time=slice("2000-01-01T00:00:00", "2000-01-01T03:00:00")))
+    filters.crop.update(dict(time=Slice(start="2000-01-01T00:00:00", stop="2000-01-01T03:00:00")))
     filters.crop.update(
-        dict(longitude=slice(115.5, 116.0), latitude=slice(-33.0, -32.5))
+        dict(longitude=Slice(start=115.5, stop=116.0), latitude=Slice(start=-33.0, stop=-32.5))
     )
     dset = dataset.open(
         variables=["u10"],


### PR DESCRIPTION
`SourceDatamesh` overwrites the `open()` method, and the filtering call had not been defined. This fixes that so these sources will use user-defined filters as expected.