### PR TITLE
Added option to skip generate in the run commmand

### DIFF
--- a/src/rompy/cli.py
+++ b/src/rompy/cli.py
@@ -213,11 +213,17 @@ def cli(ctx):
     help="YAML/JSON file with backend configuration",
 )
 @click.option("--dry-run", is_flag=True, help="Generate inputs only, don't run")
+@click.option(
+    "--skip-generate",
+    is_flag=True,
+    help="Skip generation step, use existing workspace (must already exist)",
+)
 @add_common_options
 def run(
     config,
     backend_config,
     dry_run,
+    skip_generate,
     verbose,
     log_dir,
     show_warnings,
@@ -236,36 +242,54 @@ def run(
 
         # Run with config from environment variable
         rompy run --config-from-env --backend-config unified_local_single.yml
+
+        # Use pre-generated workspace (two-step workflow)
+        rompy generate config.yml
+        rompy run config.yml --backend-config backend.yml --skip-generate
     """
     configure_logging(verbose, log_dir, simple_logs, ascii_only, show_warnings)
 
-    # Validate config source
+    if skip_generate and dry_run:
+        raise click.UsageError("Cannot use --skip-generate with --dry-run")
+
     if config_from_env and config:
         raise click.UsageError("Cannot specify both config file and --config-from-env")
     if not config_from_env and not config:
         raise click.UsageError("Must specify either config file or --config-from-env")
 
     try:
-        # Load model configuration
         config_data = load_config(config, from_env=config_from_env)
         model_run = ModelRun(**config_data)
 
         logger.info(f"Running model: {model_run.config.model_type}")
         logger.info(f"Run ID: {model_run.run_id}")
 
-        # Load backend configuration
         backend_cfg = _load_backend_config(backend_config)
 
-        # Generate inputs
         start_time = datetime.now()
-        staging_dir = model_run.generate()
-        logger.info(f"Inputs generated in: {staging_dir}")
+
+        if skip_generate:
+            staging_dir = str(model_run.staging_dir)
+            staging_path = Path(staging_dir)
+            if not staging_path.exists():
+                raise click.UsageError(
+                    f"Workspace does not exist: {staging_dir}\n"
+                    f"Run 'rompy generate {config or '<config>'}' first or remove --skip-generate"
+                )
+            if not list(staging_path.glob("*")):
+                raise click.UsageError(
+                    f"Workspace exists but is empty: {staging_dir}\n"
+                    f"Run 'rompy generate {config or '<config>'}' first or remove --skip-generate"
+                )
+            logger.info(f"Using existing workspace: {staging_dir}")
+        else:
+            staging_dir = model_run.generate()
+            logger.info(f"Inputs generated in: {staging_dir}")
 
         if dry_run:
             logger.info("Dry run mode - skipping model execution")
             return
 
-        # Execute model with workspace directory to avoid double generation
         success = model_run.run(backend=backend_cfg, workspace_dir=staging_dir)
 
         elapsed = datetime.now() - start_time


### PR DESCRIPTION
`rompy run` was always running generate, even if `rompy generate` had already been run. This provides the option to avoid doing that