### PR TITLE
Add Pydantic-based postprocessor configuration framework

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -33,6 +33,24 @@ are continually evolving. Contributions and feedback are welcome!
 Releases
 ********
 
+0.6.0 (2026-02-18)
+___________________
+
+Breaking Changes
+----------------
+* CLI: Replaced `--processor` option with `--processor-config` (required) in `rompy postprocess` and `rompy pipeline` commands.
+* API: `ModelRun.postprocess()` now requires a `BasePostprocessorConfig` instance instead of a string processor name.
+* Pipeline: `LocalPipelineBackend.execute()` now accepts a `BasePostprocessorConfig` instance for the `processor` parameter.
+
+New Features
+------------
+* Added Pydantic-based postprocessor configuration framework (`BasePostprocessorConfig`, `NoopPostprocessorConfig`).
+* Added `--processor-config` CLI option for specifying postprocessor configuration files (YAML/JSON).
+* Added `rompy.postprocess.config` entry point group for registering postprocessor configurations.
+* Added `rompy backends validate --processor-type` for validating postprocessor configurations.
+* Added comprehensive test suite for postprocessor configuration framework.
+* Added example postprocessor configuration files.
+
 0.5.0 (2025-07-13)
 ___________________
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Key Features:
 - Templated, reproducible model configuration using pydantic and xarray
 - Unified interfaces for grids, data, boundaries, and spectra
 - Extensible plugin system for models, data sources, backends, and postprocessors
+- Pydantic-based postprocessor configuration with CLI support
 - Robust logging and formatting for consistent output and diagnostics
 - Example notebooks and comprehensive documentation for rapid onboarding
 - Support for local, Docker, and HPC execution backends
@@ -27,6 +28,42 @@ rompy is under active development—features, model support, and documentation a
 # Documentation
 
 See <https://rom-py.github.io/rompy/>
+
+# Postprocessor Configuration
+
+ROMPY now supports Pydantic-based postprocessor configuration via YAML/JSON files.
+
+## Usage
+
+### Postprocess with a config file
+
+```bash
+rompy postprocess model_config.yml --processor-config processor.yml
+```
+
+### Pipeline with postprocessor config
+
+```bash
+rompy pipeline model_config.yml --processor-config processor.yml
+```
+
+### Validate a postprocessor config
+
+```bash
+rompy backends validate --processor-type noop processor.yml
+```
+
+## Example Configuration
+
+```yaml
+type: noop
+validate_outputs: true
+timeout: 3600
+env_vars:
+  DEBUG: "1"
+```
+
+See `examples/backends/postprocessor_configs/` for more examples.
 
 # Code Formatting and Pre-commit Hooks
 

--- a/examples/backends/postprocessor_configs/README.md
+++ b/examples/backends/postprocessor_configs/README.md
@@ -1,0 +1,45 @@
+# Postprocessor Configuration Examples
+
+This directory contains example postprocessor configuration files for ROMPY.
+
+## Available Postprocessors
+
+### Noop Postprocessor
+
+The `noop` postprocessor is a placeholder that performs no actual processing but can optionally validate that model outputs exist.
+
+## Files
+
+- **noop_basic.yml** - Minimal configuration with just the required type field
+- **noop_advanced.yml** - Shows all available configuration options
+
+## Usage
+
+### Validate a configuration file
+
+```bash
+rompy backends validate --processor-type noop noop_basic.yml
+```
+
+### Use in postprocessing
+
+```bash
+rompy postprocess model_config.yml --processor-config noop_basic.yml
+```
+
+### Use in pipeline
+
+```bash
+rompy pipeline model_config.yml --processor-config noop_basic.yml
+```
+
+## Configuration Schema
+
+All postprocessor configurations share these common fields:
+
+- **type** (required): The postprocessor type (e.g., "noop")
+- **timeout** (optional): Maximum execution time in seconds (60-86400, default: 3600)
+- **env_vars** (optional): Dictionary of environment variables
+- **working_dir** (optional): Working directory for execution
+
+Processor-specific fields vary by type. See individual example files for details.

--- a/examples/backends/postprocessor_configs/noop_advanced.yml
+++ b/examples/backends/postprocessor_configs/noop_advanced.yml
@@ -1,0 +1,23 @@
+# Advanced Noop Postprocessor Configuration
+# Shows all available options for the noop postprocessor
+
+# Required: specifies this is a noop postprocessor
+type: noop
+
+# Whether to validate that expected output files exist
+# Default: true
+validate_outputs: true
+
+# Maximum execution time in seconds (60-86400)
+# Default: 3600 (1 hour)
+timeout: 3600
+
+# Additional environment variables to set during execution
+# Default: {}
+env_vars:
+  DEBUG: "1"
+  LOG_LEVEL: "INFO"
+
+# Working directory for execution
+# If not specified, uses model output directory
+# working_dir: /path/to/output

--- a/examples/backends/postprocessor_configs/noop_basic.yml
+++ b/examples/backends/postprocessor_configs/noop_basic.yml
@@ -1,0 +1,5 @@
+# Basic Noop Postprocessor Configuration
+# This is the simplest possible postprocessor config - just validate outputs exist
+
+type: noop
+validate_outputs: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ slurm = "rompy.run.slurm:SlurmRunBackend"
 [project.entry-points."rompy.postprocess"]
 noop = "rompy.postprocess:NoopPostprocessor"
 
+[project.entry-points."rompy.postprocess.config"]
+noop = "rompy.postprocess.config:NoopPostprocessorConfig"
+
 [project.entry-points."rompy.pipeline"]
 local = "rompy.pipeline:LocalPipelineBackend"
 

--- a/src/rompy/postprocess/__init__.py
+++ b/src/rompy/postprocess/__init__.py
@@ -1,14 +1,28 @@
 """
-No-op postprocessor for model outputs.
+Postprocessor module for ROMPY.
 
-This module provides a basic postprocessor that does nothing.
+This module provides postprocessor classes and their configurations for
+processing model outputs after execution.
 """
 
 import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
+from .config import (
+    BasePostprocessorConfig,
+    NoopPostprocessorConfig,
+    ProcessorConfig,
+)
+
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "NoopPostprocessor",
+    "NoopPostprocessorConfig",
+    "BasePostprocessorConfig",
+    "ProcessorConfig",
+]
 
 
 class NoopPostprocessor:

--- a/src/rompy/postprocess/config.py
+++ b/src/rompy/postprocess/config.py
@@ -1,0 +1,226 @@
+"""
+Postprocessor configuration classes for ROMPY.
+
+This module provides Pydantic-based configuration classes for different
+postprocessor types. These configurations handle transient execution parameters
+while maintaining type safety and validation.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from . import NoopPostprocessor
+
+
+class BasePostprocessorConfig(BaseModel, ABC):
+    """Base class for all postprocessor configurations.
+
+    This class defines common configuration parameters that apply to all
+    postprocessor types, such as timeouts and environment variables.
+    """
+
+    timeout: int = Field(
+        3600,
+        ge=60,
+        le=86400,
+        description="Maximum execution time in seconds (1 minute to 24 hours)",
+    )
+
+    env_vars: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables to set during execution",
+    )
+
+    working_dir: Optional[Path] = Field(
+        None,
+        description="Working directory for execution (defaults to model output directory)",
+    )
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+        extra="forbid",  # Don't allow extra fields
+        use_enum_values=True,
+    )
+
+    @field_validator("working_dir")
+    @classmethod
+    def validate_working_dir(cls, v):
+        """Validate working directory exists if specified."""
+        if v is not None:
+            path = Path(v)
+            if not path.exists():
+                raise ValueError(f"Working directory does not exist: {path}")
+            if not path.is_dir():
+                raise ValueError(f"Working directory is not a directory: {path}")
+        return v
+
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_vars(cls, v):
+        """Validate environment variables."""
+        if not isinstance(v, dict):
+            raise ValueError("env_vars must be a dictionary")
+
+        for key, value in v.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError("Environment variable keys and values must be strings")
+            if not key:
+                raise ValueError("Environment variable keys cannot be empty")
+
+        return v
+
+    @abstractmethod
+    def get_postprocessor_class(self):
+        """Return the postprocessor class that should handle this configuration.
+
+        Returns:
+            The postprocessor class to use for execution
+        """
+        pass
+
+
+class NoopPostprocessorConfig(BasePostprocessorConfig):
+    """Configuration for no-operation postprocessor.
+
+    This configuration is used when no postprocessing is required but output
+    validation may still be needed. It provides the simplest postprocessor
+    that can optionally validate that model outputs exist.
+    """
+
+    type: Literal["noop"] = "noop"
+
+    validate_outputs: bool = Field(
+        True, description="Whether to validate that expected outputs exist"
+    )
+
+    def get_postprocessor_class(self):
+        """Return the NoopPostprocessor class."""
+        from . import NoopPostprocessor
+
+        return NoopPostprocessor
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "type": "noop",
+                    "timeout": 3600,
+                    "validate_outputs": True,
+                },
+                {
+                    "type": "noop",
+                    "timeout": 1800,
+                    "validate_outputs": False,
+                    "env_vars": {"DEBUG": "1"},
+                },
+                {"type": "noop", "working_dir": "/path/to/output/dir"},
+            ]
+        }
+    )
+
+
+# Type alias for all postprocessor configurations
+ProcessorConfig = Union[NoopPostprocessorConfig]
+
+
+def _load_processor_config(config_file):
+    """Load postprocessor configuration from a YAML or JSON file.
+
+    This function reads a configuration file, extracts the processor type,
+    and instantiates the appropriate configuration class using entry points.
+
+    Args:
+        config_file: Path to the configuration file (YAML or JSON)
+
+    Returns:
+        An instance of the appropriate postprocessor config class
+
+    Raises:
+        ValueError: If the processor type is not found in registered entry points
+        FileNotFoundError: If the config file doesn't exist
+        yaml.YAMLError: If the file is neither valid JSON nor valid YAML
+    """
+    import json
+    from importlib.metadata import entry_points
+
+    path = Path(config_file)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_file}")
+
+    content = path.read_text()
+
+    # Try JSON first, then YAML
+    try:
+        config_data = json.loads(content)
+    except json.JSONDecodeError:
+        import yaml
+
+        config_data = yaml.safe_load(content)
+
+    if not isinstance(config_data, dict):
+        raise ValueError(
+            f"Config file must contain a dictionary, got {type(config_data)}"
+        )
+
+    processor_type = config_data.pop("type", None)
+
+    if processor_type is None:
+        raise ValueError("Config file must contain a 'type' field")
+
+    # Load from entry point
+    eps = entry_points(group="rompy.postprocess.config")
+    for ep in eps:
+        if ep.name == processor_type:
+            config_class = ep.load()
+            return config_class(**config_data)
+
+    # If we get here, type wasn't found
+    available = [ep.name for ep in eps]
+    if available:
+        available_str = ", ".join(available)
+        raise ValueError(
+            f"Unknown processor type: '{processor_type}'. Available types: {available_str}"
+        )
+    else:
+        raise ValueError(
+            f"Unknown processor type: '{processor_type}'. No postprocessor types are registered."
+        )
+
+
+def validate_postprocessor_config(config_file, processor_type=None):
+    """Validate a postprocessor configuration file.
+
+    This function validates that a configuration file is valid YAML/JSON,
+    contains a valid processor type, and can be instantiated.
+
+    Args:
+        config_file: Path to the configuration file to validate
+        processor_type: Optional specific processor type to validate against.
+                       If None, validates against the type in the config.
+
+    Returns:
+        Tuple of (is_valid: bool, message: str, config: Optional[BasePostprocessorConfig])
+    """
+    try:
+        config = _load_processor_config(config_file)
+
+        if processor_type is not None and config.type != processor_type:
+            return (
+                False,
+                f"Config type '{config.type}' does not match expected type '{processor_type}'",
+                None,
+            )
+
+        return (True, f"Valid {config.type} configuration", config)
+
+    except FileNotFoundError as e:
+        return (False, f"Config file not found: {e}", None)
+    except ValueError as e:
+        return (False, f"Validation error: {e}", None)
+    except Exception as e:
+        return (False, f"Unexpected error: {e}", None)

--- a/tests/test_postprocess_config.py
+++ b/tests/test_postprocess_config.py
@@ -1,0 +1,234 @@
+"""
+Tests for postprocessor configuration framework.
+
+This module tests the postprocessor config classes, loading, and validation.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rompy.postprocess import (
+    BasePostprocessorConfig,
+    NoopPostprocessorConfig,
+    ProcessorConfig,
+)
+from rompy.postprocess.config import (
+    _load_processor_config,
+    validate_postprocessor_config,
+)
+
+
+class TestBasePostprocessorConfig:
+    """Tests for BasePostprocessorConfig abstract base class."""
+
+    def test_is_abstract(self):
+        """Test that BasePostprocessorConfig cannot be instantiated."""
+        with pytest.raises(TypeError):
+            BasePostprocessorConfig()
+
+    def test_can_subclass(self):
+        """Test that BasePostprocessorConfig can be subclassed."""
+
+        class TestConfig(BasePostprocessorConfig):
+            type: str = "test"
+
+            def get_postprocessor_class(self):
+                return object
+
+        # Should not raise
+        config = TestConfig()
+        assert config.timeout == 3600
+        assert config.env_vars == {}
+        assert config.working_dir is None
+
+
+class TestNoopPostprocessorConfig:
+    """Tests for NoopPostprocessorConfig concrete class."""
+
+    def test_default_values(self):
+        """Test default values are set correctly."""
+        config = NoopPostprocessorConfig()
+        assert config.type == "noop"
+        assert config.validate_outputs is True
+        assert config.timeout == 3600
+        assert config.env_vars == {}
+        assert config.working_dir is None
+
+    def test_custom_values(self):
+        """Test custom values can be set."""
+        config = NoopPostprocessorConfig(
+            validate_outputs=False,
+            timeout=7200,
+            env_vars={"DEBUG": "1"},
+        )
+        assert config.validate_outputs is False
+        assert config.timeout == 7200
+        assert config.env_vars == {"DEBUG": "1"}
+
+    def test_validation_rejects_invalid_timeout(self):
+        """Test that invalid timeout values are rejected."""
+        with pytest.raises(ValueError):
+            NoopPostprocessorConfig(timeout=30)  # Below minimum
+
+        with pytest.raises(ValueError):
+            NoopPostprocessorConfig(timeout=90000)  # Above maximum
+
+    def test_get_postprocessor_class(self):
+        """Test that get_postprocessor_class returns NoopPostprocessor."""
+        from rompy.postprocess import NoopPostprocessor
+
+        config = NoopPostprocessorConfig()
+        processor_class = config.get_postprocessor_class()
+        assert processor_class is NoopPostprocessor
+
+
+class TestLoadProcessorConfig:
+    """Tests for _load_processor_config function."""
+
+    def test_load_from_yaml(self, tmp_path):
+        """Test loading config from YAML file."""
+        config_file = tmp_path / "test_config.yml"
+        config_data = {"type": "noop", "validate_outputs": False}
+        config_file.write_text(yaml.dump(config_data))
+
+        config = _load_processor_config(config_file)
+        assert isinstance(config, NoopPostprocessorConfig)
+        assert config.type == "noop"
+        assert config.validate_outputs is False
+
+    def test_load_from_json(self, tmp_path):
+        """Test loading config from JSON file."""
+        config_file = tmp_path / "test_config.json"
+        config_data = {"type": "noop", "timeout": 7200}
+        config_file.write_text(json.dumps(config_data))
+
+        config = _load_processor_config(config_file)
+        assert isinstance(config, NoopPostprocessorConfig)
+        assert config.timeout == 7200
+
+    def test_file_not_found(self, tmp_path):
+        """Test error when file doesn't exist."""
+        config_file = tmp_path / "nonexistent.yml"
+
+        with pytest.raises(FileNotFoundError):
+            _load_processor_config(config_file)
+
+    def test_missing_type_field(self, tmp_path):
+        """Test error when type field is missing."""
+        config_file = tmp_path / "bad_config.yml"
+        config_file.write_text(yaml.dump({"validate_outputs": True}))
+
+        with pytest.raises(ValueError, match="type"):
+            _load_processor_config(config_file)
+
+    def test_unknown_processor_type(self, tmp_path):
+        """Test error for unknown processor type."""
+        config_file = tmp_path / "unknown_config.yml"
+        config_file.write_text(yaml.dump({"type": "unknown"}))
+
+        with pytest.raises(ValueError, match="Unknown processor type"):
+            _load_processor_config(config_file)
+
+
+class TestValidatePostprocessorConfig:
+    """Tests for validate_postprocessor_config function."""
+
+    def test_valid_config(self, tmp_path):
+        """Test validation passes for valid config."""
+        config_file = tmp_path / "valid_config.yml"
+        config_file.write_text(yaml.dump({"type": "noop"}))
+
+        is_valid, message, config = validate_postprocessor_config(config_file)
+        assert is_valid is True
+        assert "Valid" in message
+        assert isinstance(config, NoopPostprocessorConfig)
+
+    def test_type_mismatch(self, tmp_path):
+        """Test validation fails when type doesn't match expected."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(yaml.dump({"type": "noop"}))
+
+        is_valid, message, config = validate_postprocessor_config(
+            config_file, processor_type="other"
+        )
+        assert is_valid is False
+        assert "does not match" in message
+        assert config is None
+
+    def test_file_not_found(self, tmp_path):
+        """Test validation handles missing file."""
+        config_file = tmp_path / "nonexistent.yml"
+
+        is_valid, message, config = validate_postprocessor_config(config_file)
+        assert is_valid is False
+        assert "not found" in message
+        assert config is None
+
+
+class TestProcessorConfigTypeAlias:
+    """Tests for ProcessorConfig type alias."""
+
+    def test_is_union(self):
+        """Test that ProcessorConfig is a Union type or single type."""
+        import typing
+
+        origin = typing.get_origin(ProcessorConfig)
+        # Union[SingleType] is optimized to just SingleType
+        assert origin is typing.Union or ProcessorConfig is NoopPostprocessorConfig
+
+    def test_includes_noop(self):
+        """Test that ProcessorConfig includes NoopPostprocessorConfig."""
+        import typing
+
+        args = typing.get_args(ProcessorConfig)
+        # Union[SingleType] is optimized to just SingleType
+        assert (
+            NoopPostprocessorConfig in args
+            or ProcessorConfig is NoopPostprocessorConfig
+        )
+
+
+class TestModelRunIntegration:
+    """Integration tests for ModelRun.postprocess with config objects."""
+
+    def test_postprocess_accepts_config(self):
+        """Test that ModelRun.postprocess accepts config objects."""
+        from rompy.core.time import TimeRange
+        from rompy.model import ModelRun
+        from datetime import datetime
+
+        model = ModelRun(
+            run_id="test",
+            period=TimeRange(
+                start=datetime(2020, 1, 1),
+                end=datetime(2020, 1, 2),
+                interval="1H",
+            ),
+        )
+
+        config = NoopPostprocessorConfig(validate_outputs=False)
+        # Should not raise TypeError
+        result = model.postprocess(config)
+        assert isinstance(result, dict)
+
+    def test_postprocess_rejects_string(self):
+        """Test that ModelRun.postprocess rejects string processor names."""
+        from rompy.core.time import TimeRange
+        from rompy.model import ModelRun
+        from datetime import datetime
+
+        model = ModelRun(
+            run_id="test",
+            period=TimeRange(
+                start=datetime(2020, 1, 1),
+                end=datetime(2020, 1, 2),
+                interval="1H",
+            ),
+        )
+
+        with pytest.raises(TypeError, match="BasePostprocessorConfig"):
+            model.postprocess("noop")


### PR DESCRIPTION
## Summary

Implements a comprehensive Pydantic-based postprocessor configuration framework that brings parity with the run backend configuration system. Enables configuration-driven postprocessing via YAML/JSON files with CLI support.

## Motivation

The existing postprocessing system used string-based processor names, which lacked type safety, validation, and extensibility. This implementation provides:

- Type-safe configuration with Pydantic validation
- Entry point-based dynamic loading
- Consistent API with backend configuration system
- Full CLI integration
- Enhanced developer experience for custom postprocessors

## Changes

### Core Implementation

**New Files:**
- `src/rompy/postprocess/config.py` (226 lines) - Configuration classes and loading infrastructure
- `tests/test_postprocess_config.py` (234 lines) - Comprehensive test suite (18 tests)
- `examples/backends/postprocessor_configs/` - Example YAML configurations with documentation

**Modified Files:**
- `src/rompy/cli.py` - Updated CLI commands with `--processor-config` option
- `src/rompy/model.py` - Updated `postprocess()` to require config objects
- `src/rompy/pipeline/__init__.py` - Updated LocalPipelineBackend for config objects
- `pyproject.toml` - Added entry point registration
- `tests/backends/test_enhanced_backends.py` - Updated all pipeline tests

### Documentation

Updated 5 documentation files with 1064+ lines of new content:
- `docs/cli.md` - CLI options and usage
- `docs/backends.md` - Postprocessor configuration guide
- `docs/plugin_architecture.md` - Plugin development
- `docs/configuration_deep_dive.md` - Configuration patterns
- `docs/developer/backend_reference.md` - Developer reference

## Breaking Changes

### API Changes

**Old (removed):**
```python
model_run.postprocess(processor="noop")
```

**New (required):**
```python
from rompy.postprocess.config import NoopPostprocessorConfig
config = NoopPostprocessorConfig(validate_outputs=True)
model_run.postprocess(processor=config)
```

### CLI Changes

**Old (removed):**
```bash
rompy pipeline config.yml --processor noop
```

**New (required):**
```bash
rompy pipeline config.yml --processor-config processor.yml
```

## Features

### Configuration Classes

- `BasePostprocessorConfig` - Abstract base with common fields
- `NoopPostprocessorConfig` - Concrete implementation for validation-only processing
- `ProcessorConfig` - Type alias for Union of all processor configs

### Entry Point System

Configurations are dynamically loaded via entry points:

```toml
[project.entry-points."rompy.postprocess.config"]
noop = "rompy.postprocess.config:NoopPostprocessorConfig"
```

### CLI Integration

- `rompy postprocess` - Process existing model outputs with config file
- `rompy pipeline` - Updated to require `--processor-config` option
- `rompy backends validate` - Added `--processor-type` option for validation

### Configuration File Format

```yaml
type: noop
validate_outputs: true
timeout: 3600
env_vars:
  DEBUG: "1"
  LOG_LEVEL: "INFO"
```

## Testing

- ✅ 18 new tests (all passing)
- ✅ 254 total tests passing
- ✅ 15 skipped
- ✅ All existing pipeline tests updated

## Migration Guide

### For Users

1. Replace string processor names with configuration files:
   ```bash
   # Create processor.yml
   cat > processor.yml <<EOF
   type: noop
   validate_outputs: true
   timeout: 3600
   EOF
   
   # Use in commands
   rompy postprocess model.yml --processor-config processor.yml
   ```

2. Update Python code:
   ```python
   from rompy.postprocess.config import NoopPostprocessorConfig
   
   config = NoopPostprocessorConfig(validate_outputs=True)
   results = model_run.postprocess(processor=config)
   ```

### For Plugin Developers

1. Create configuration class:
   ```python
   from rompy.postprocess.config import BasePostprocessorConfig
   from pydantic import Field
   
   class MyProcessorConfig(BasePostprocessorConfig):
       type: str = Field("myprocessor", const=True)
       custom_field: str = Field(..., description="Custom parameter")
       
       def get_postprocessor_class(self):
           from mypackage import MyPostprocessor
           return MyPostprocessor
   ```

2. Register in `pyproject.toml`:
   ```toml
   [project.entry-points."rompy.postprocess.config"]
   myprocessor = "mypackage:MyProcessorConfig"
   ```

## Examples

See `examples/backends/postprocessor_configs/` for:
- `noop_basic.yml` - Minimal configuration
- `noop_advanced.yml` - Advanced options
- `README.md` - Usage documentation

## Backward Compatibility

**No backward compatibility maintained.** The postprocessing framework is relatively new, and the priority is a clean, functional implementation over maintaining the old string-based API.

## Related Issues

Addresses the need for configuration-driven postprocessing to match the existing backend configuration framework.

## Checklist

- [x] Implementation complete
- [x] Tests passing (254/254)
- [x] Documentation updated (5 files)
- [x] Example configurations created
- [x] Entry points registered
- [x] Breaking changes documented
- [x] Migration guide provided

## Changelog Entry

Added to `HISTORY.rst` for v0.6.0:

**Breaking Changes:**
- Postprocessor API now requires Pydantic configuration objects instead of strings
- CLI `--processor` option replaced with `--processor-config` (required)

**New Features:**
- Pydantic-based postprocessor configuration framework
- Entry point-based dynamic configuration loading
- CLI support for postprocessor configuration files
- Configuration validation and schema generation

---

**Note:** This PR does not require backward compatibility as the postprocessing system is relatively new.