### PR TITLE
Fix PyPI upload failure by removing git dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ docs = [
     "mkdocs-execute-plugin",
     "mkdocs-jupyter",
 ]
-notebooks = [
-    "rompy-notebooks @ git+https://github.com/rom-py/rompy-notebooks.git@package",
-]
 dev = ["pytest", "envyaml", "coverage", "ruff", "black", "respx"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
Removes the `notebooks` optional dependency that was causing PyPI upload failures.

## Problem
The v0.6.3 release failed to upload to PyPI with this error:
```
ERROR: Can't have direct dependency: rompy-notebooks @ 
git+https://github.com/rom-py/rompy-notebooks.git@package ; extra == "notebooks"
```

PyPI does not allow direct git dependencies in package metadata, even in optional extras, because they are not reproducible or verifiable according to PEP 440.

## Solution
Removed the `notebooks` optional dependency from `pyproject.toml`. This dependency is not needed for package distribution because:

1. The docs build workflow (`.github/workflows/build-docs.yml`) already clones `rompy-notebooks` directly from GitHub
2. The notebooks are copied into the docs directory during the build process
3. The package is installed with `pip install .[docs]`, not `[notebooks]`

## Testing
- The change allows the package to be built and uploaded to PyPI without validation errors
- Docs build workflow remains unaffected as it handles notebooks separately

Fixes the PyPI upload failure in release v0.6.3.